### PR TITLE
Add cli_options to .pronto_stylelint.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Following options are available:
 | Option               | Meaning                                                                   | Default                                   |
 | -------------------- | ------------------------------------------------------------------------- | ----------------------------------------- |
 | stylelint_executable | stylelint executable to call.                                             | `stylelint` (calls `stylelint` in `PATH`) |
+| cli_options          | Options to pass to the CLI.                                               | `-f json`                                     |
 
-Example configuration to call custom stylelint executable:
+Example configuration to call custom stylelint executable and specify custom options:
 
 ```yaml
 # .pronto_stylelint.yml
 stylelint_executable: '/my/custom/node/path/.bin/stylelint'
+cli_options: '--config /custom/stylelintrc'
 ```

--- a/lib/pronto/stylelint.rb
+++ b/lib/pronto/stylelint.rb
@@ -4,12 +4,20 @@ require 'shellwords'
 module Pronto
   class Stylelint < Runner
     CONFIG_FILE = '.pronto_stylelint.yml'.freeze
-    CONFIG_KEYS = %w(stylelint_executable).freeze
+    CONFIG_KEYS = %w(stylelint_executable cli_options).freeze
 
-    attr_writer :stylelint_executable
+    attr_writer :stylelint_executable, :cli_options
 
     def stylelint_executable
       @stylelint_executable || 'stylelint'.freeze
+    end
+
+    def cli_options
+      if @cli_options
+        @cli_options + ' -f json'.freeze
+      else
+        '-f json'.freeze
+      end
     end
 
     def files_to_lint
@@ -71,7 +79,7 @@ module Pronto
       Dir.chdir(repo_path) do
         escaped_file_path = Shellwords.escape(patch.new_file_full_path.to_s)
         JSON.parse(
-          `#{stylelint_executable} #{escaped_file_path} -f json`
+          `#{stylelint_executable} #{escaped_file_path} #{cli_options}`
         )
       end
     end

--- a/pronto-stylelint.gemspec
+++ b/pronto-stylelint.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.requirements << 'stylelint (in PATH)'
 
   s.add_dependency('pronto', '~> 0.8.2')
+  s.add_dependency('rugged', '~> 0.24', '>= 0.23.0')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')
 end

--- a/spec/support/repository_helper.rb
+++ b/spec/support/repository_helper.rb
@@ -50,4 +50,3 @@ module RepositoryHelper
     repo.checkout(branch_name, strategy: [:force])
   end
 end
-


### PR DESCRIPTION
Allows passing of more CLI options to the stylelint command when running
in Pronto. This allows specifying a custom .stylelintrc file, for
example.

cli_options always appends -f json so the format should always be JSON.

I wanted to add this because my team would like to use pronto-stylelint but it would give us some more flexibility to store our .stylelintrc file outside of our repo, so being able to specify the --config flag would help us.