### PR TITLE
Add files_to_lint to .pronto_stylelint.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test Coverage](https://codeclimate.com/github/kevinjalbert/pronto-stylelint/badges/coverage.svg)](https://codeclimate.com/github/kevinjalbert/pronto-stylelint/coverage)
 [![Dependency Status](https://gemnasium.com/badges/github.com/kevinjalbert/pronto-stylelint.svg)](https://gemnasium.com/github.com/kevinjalbert/pronto-stylelint)
 
-Pronto runner for [stylelint](http://stylelint.io), the mighty, modern CSS linter. [What is Pronto?](https://github.com/mmozuras/pronto)
+Pronto runner for [stylelint](http://stylelint.io), the mighty, modern CSS linter. [What is Pronto?](https://github.com/prontolabs/pronto)
 
 Uses official stylelint executable installed by `npm`.
 
@@ -26,15 +26,17 @@ pronto-stylelint can be configured by placing a `.pronto_stylelint.yml` inside t
 
 Following options are available:
 
-| Option               | Meaning                                                                   | Default                                   |
-| -------------------- | ------------------------------------------------------------------------- | ----------------------------------------- |
-| stylelint_executable | stylelint executable to call.                                             | `stylelint` (calls `stylelint` in `PATH`) |
-| cli_options          | Options to pass to the CLI.                                               | `-f json`                                     |
+| Option               | Meaning                                                                                  | Default                                   |
+| -------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------- |
+| stylelint_executable | stylelint executable to call.                                                            | `stylelint` (calls `stylelint` in `PATH`) |
+| files_to_lint        | What files to lint. Absolute path of offending file will be matched against this Regexp. | `\.(c\|sc\|sa\|le)ss$`                    |
+| cli_options          | Options to pass to the CLI.                                                              | `-f json`                                 |
 
 Example configuration to call custom stylelint executable and specify custom options:
 
 ```yaml
 # .pronto_stylelint.yml
 stylelint_executable: '/my/custom/node/path/.bin/stylelint'
+files_to_lint: '\.(c|sc)ss$'
 cli_options: '--config /custom/stylelintrc'
 ```

--- a/lib/pronto/stylelint.rb
+++ b/lib/pronto/stylelint.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 module Pronto
   class Stylelint < Runner
     CONFIG_FILE = '.pronto_stylelint.yml'.freeze
-    CONFIG_KEYS = %w(stylelint_executable cli_options).freeze
+    CONFIG_KEYS = %w(stylelint_executable files_to_lint cli_options).freeze
 
     attr_writer :stylelint_executable, :cli_options
 
@@ -22,7 +22,11 @@ module Pronto
     end
 
     def files_to_lint
-      /\.(c|sc|sa|le)ss$/.freeze
+      @files_to_lint || /\.(c|sc|sa|le)ss$/.freeze
+    end
+
+    def files_to_lint=(regexp)
+      @files_to_lint = regexp.is_a?(Regexp) ? regexp : Regexp.new(regexp)
     end
 
     def read_config

--- a/spec/pronto/stylelint_spec.rb
+++ b/spec/pronto/stylelint_spec.rb
@@ -86,7 +86,7 @@ module Pronto
           before(:each) do
             create_branch("staging", checkout: true)
 
-            updated_content = <<-HEREDOC
+            add_to_index('style.css', <<-HEREDOC)
               .thing {
                 font-size:  10px;
               }
@@ -94,17 +94,45 @@ module Pronto
               a { color: pink;}
             HEREDOC
 
-            add_to_index('style.css', updated_content)
+            add_to_index('style.scss', <<-HEREDOC)
+              .thing {
+                font-size:  10px;
+
+                a { color: pink;}
+              }
+            HEREDOC
 
             create_commit
           end
 
           it 'returns correct number of warnings' do
-            expect(stylelint.run.count).to eql(2)
+            expect(stylelint.run.count).to eql(4)
           end
 
           it "has correct first message" do
             expect(stylelint.run.first.msg).to eql('Unexpected named color "pink" (color-named)')
+          end
+
+          context 'with files to lint config that matches only .css' do
+            before do
+              add_to_index('.pronto_stylelint.yml', "files_to_lint: '\\.css$'")
+              create_commit
+            end
+
+            it 'returns correct number of warnings' do
+              expect(stylelint.run.count).to eql(2)
+            end
+          end
+
+          context 'with files to lint config that never matches' do
+            before do
+              add_to_index('.pronto_stylelint.yml', "files_to_lint: 'will never match'")
+              create_commit
+            end
+
+            it 'returns zero warnings' do
+              expect(stylelint.run.count).to eql(0)
+            end
           end
         end
 


### PR DESCRIPTION
Stylelint hasn't been working well with SASS files for me (there is no working Sass syntax parser for PostCSS), that’s why I would like to have `files_to_lint` option configurable to only lint *.scss files.

This option is configurable in `pronto-eslint_npm` gem and that is very helpful.

Example .pronto_stylelint.yml:
``` yaml
stylelint_executable: './node_modules/.bin/stylelint'
files_to_lint: '\.(c|sc)ss$'