### PR TITLE
Use popen3 to detect json in stderr

### DIFF
--- a/spec/pronto/stylelint_spec.rb
+++ b/spec/pronto/stylelint_spec.rb
@@ -65,14 +65,14 @@ module Pronto
             {
               "rules": {
                 "color-named": "never",
-                "unit-whitelist": ["em"]
+                "unit-no-unknown": true
               }
             }
           HEREDOC
 
           content = <<-HEREDOC
             .thing {
-              font-size: 10em;
+              font-size: 10pxem;
             }
           HEREDOC
 
@@ -88,7 +88,7 @@ module Pronto
 
             add_to_index('style.css', <<-HEREDOC)
               .thing {
-                font-size:  10px;
+                font-size:  10pxem;
               }
 
               a { color: pink;}
@@ -96,7 +96,7 @@ module Pronto
 
             add_to_index('style.scss', <<-HEREDOC)
               .thing {
-                font-size:  10px;
+                font-size:  10pxem;
 
                 a { color: pink;}
               }


### PR DESCRIPTION
## Why are the changes necessary?

Just recently running `pronto-stylelint` started to throw errors like:

```sh
Running Pronto::Stylelint
[{"source":"/home/circleci/project/app/frontend/stylesheets/backoffice/_editor.scss","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":false,"warnings":[]}]bin/rails aborted!
JSON::ParserError: unexpected token at '' (JSON::ParserError)
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/json-2.7.1/lib/json/common.rb:219:in `parse'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/json-2.7.1/lib/json/common.rb:219:in `parse'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:84:in `block in run_stylelint'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:82:in `chdir'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:82:in `run_stylelint'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:60:in `inspect'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:49:in `block in run'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:49:in `map'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-stylelint-0.10.2/lib/pronto/stylelint.rb:49:in `run'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-0.11.2/lib/pronto/runners.rb:20:in `block in run'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-0.11.2/lib/pronto/runners.rb:13:in `each'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-0.11.2/lib/pronto/runners.rb:13:in `run'
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/pronto-0.11.2/lib/pronto.rb:66:in `run'
/home/circleci/project/lib/tasks/ci.rake:71:in `block (2 levels) in <main>'
```

The cause seems to be that `stylelint` does not write the formatted output to `stdout` but to `stderr` (AFAIU).

I could not find the specific commit that changed the behaviour in https://github.com/stylelint/stylelint but I tested the changed code with version `15.0.0` and `16.1.0` – by running the specs locally – and could not find any issues.


## What changed?

- Use `Open3.popen3` to execute shell command and get access to `stderr` instead of using Kernel.\`
- Updates specs: v16 of Stylelint dropped a lot of rules (see https://github.com/stylelint/stylelint/pull/6979)