### PR TITLE
Handle Stylelint 16 Output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,15 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  NewCops: enable
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Metrics/MethodLength:
   Max: 20
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/AbcSize:
@@ -16,3 +17,7 @@ Metrics/AbcSize:
 
 Metrics/ParameterLists:
   Max: 10
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.4'
+gem 'rubocop'
+
 group :test do
-  gem 'simplecov'
   gem 'codeclimate-test-reporter', '~> 1.0.0'
+  gem 'simplecov'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 Pronto runner for [stylelint](http://stylelint.io), the mighty, modern CSS linter. [What is Pronto?](https://github.com/prontolabs/pronto)
 
-Uses official stylelint executable installed by `npm`.
+Uses the official stylelint executable installed by `npm`.
 
 Heavily inspired by [doits/pronto-eslint_npm](https://github.com/doits/pronto-eslint_npm).
 
 ## Prerequisites
 
-You'll need to install [stylelint by yourself with npm](http://stylelint.io/user-guide/cli/). If `stylelint` is in your `PATH`, everything will simply work, otherwise you have to provide pronto-stylelint your custom executable path (see [below](#configuration-of-stylelint)).
+You'll need to install [stylelint by yourself with npm](http://stylelint.io/user-guide/cli/). If `stylelint` is in your `PATH`, everything will simply work, otherwise, you have to provide pronto-stylelint your custom executable path (see [below](#configuration-of-stylelint)).
 
 ## Configuration of stylelint
 
@@ -21,9 +21,9 @@ Configuring stylelint via [.stylelintrc and consorts](http://stylelint.io/user-g
 
 ## Configuration of pronto-stylelint
 
-pronto-stylelint can be configured by placing a `.pronto_stylelint.yml` inside the directory where pronto is run.
+pronto-stylelint can be configured by adding to the [pronto configuration file](https://github.com/prontolabs/pronto?tab=readme-ov-file#configuration) `.pronto.yml`.
 
-Following options are available:
+The following options are available:
 
 | Option               | Meaning                                                                                  | Default                                   |
 | -------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------- |
@@ -34,8 +34,9 @@ Following options are available:
 Example configuration to call custom stylelint executable and specify custom options:
 
 ```yaml
-# .pronto_stylelint.yml
-stylelint_executable: '/my/custom/node/path/.bin/stylelint'
-files_to_lint: '\.(c|sc)ss$'
-cli_options: '--config /custom/stylelintrc'
+# .pronto.yml
+stylelint:
+  stylelint_executable: '/my/custom/node/path/.bin/stylelint'
+  files_to_lint: '\.(c|sc)ss$'
+  cli_options: '--config /custom/stylelintrc'
 ```

--- a/lib/pronto/stylelint.rb
+++ b/lib/pronto/stylelint.rb
@@ -1,71 +1,55 @@
+# frozen_string_literal: true
+
 require 'pronto'
 require 'shellwords'
 require 'open3'
+require 'pronto/stylelint/config'
 
 module Pronto
   class Stylelint < Runner
-    CONFIG_FILE = '.pronto_stylelint.yml'.freeze
-    CONFIG_KEYS = %w(stylelint_executable files_to_lint cli_options).freeze
+    extend Forwardable
 
-    attr_writer :stylelint_executable, :cli_options
+    CONFIG_FILE = '.pronto_stylelint.yml'
+    CONFIG_KEYS = %w[stylelint_executable files_to_lint cli_options].freeze
+    DEPRECATED_CONFIG =
+      "Pronto::Stylelint: Using %<config_key>s from #{CONFIG_FILE} is deprecated. " \
+      'Use .pronto.yml instead.'
+
+    def_delegators(
+      :stylelint_config,
+      :stylelint_executable,
+      :cli_options,
+      :files_to_lint,
+      :git_repo_path
+    )
+    private :stylelint_executable, :cli_options, :files_to_lint, :git_repo_path
 
     def initialize(patches, commit = nil)
-      super(patches, commit)
-      read_config
-    end
-
-    def stylelint_executable
-      @stylelint_executable || 'stylelint'.freeze
-    end
-
-    def cli_options
-      "#{@cli_options} -f json".strip
-    end
-
-    def files_to_lint
-      @files_to_lint || /\.(c|sc|sa|le)ss$/.freeze
-    end
-
-    def files_to_lint=(regexp)
-      @files_to_lint = regexp.is_a?(Regexp) ? regexp : Regexp.new(regexp)
-    end
-
-    def read_config
-      config_file = File.join(git_repo_path, CONFIG_FILE)
-      return unless File.exist?(config_file)
-      config = YAML.load_file(config_file)
-
-      CONFIG_KEYS.each do |config_key|
-        next unless config[config_key]
-        send("#{config_key}=", config[config_key])
-      end
+      super
     end
 
     def run
       return [] if !@patches || @patches.count.zero?
 
       @patches
-        .select { |patch| patch.additions > 0 }
-        .select { |patch| style_file?(patch.new_file_full_path) }
-        .map { |patch| inspect(patch) }
-        .flatten.compact
+        .select { |patch| patch.additions.positive? && style_file?(patch.new_file_full_path) }
+        .flat_map { |patch| inspect(patch) }
+        .compact
     end
 
     private
 
-    def git_repo_path
-      @git_repo_path ||= Rugged::Repository.discover(File.expand_path(Dir.pwd)).workdir
+    def cli_command(escaped_file_path)
+      "#{stylelint_executable} #{escaped_file_path} #{cli_options}"
     end
 
     def inspect(patch)
-      offences = run_stylelint(patch)
-      clean_up_stylelint_output(offences)
-        .map do |offence|
-          patch
-            .added_lines
-            .select { |line| line.new_lineno == offence['line'] }
-            .map { |line| new_message(offence, line) }
-        end
+      clean_up_stylelint_output(run_stylelint(patch)).flat_map do |offence|
+        patch
+          .added_lines
+          .select { |line| line.new_lineno == offence['line'] }
+          .map { |line| new_message(offence, line) }
+      end
     end
 
     def new_message(offence, line)
@@ -75,6 +59,10 @@ module Pronto
       Message.new(path, line, level, offence['text'], nil, self.class)
     end
 
+    def stylelint_config
+      @stylelint_config ||= Pronto::Stylelint::Config.new
+    end
+
     def style_file?(path)
       files_to_lint =~ path.to_s
     end
@@ -82,13 +70,13 @@ module Pronto
     def run_stylelint(patch)
       Dir.chdir(git_repo_path) do
         escaped_file_path = Shellwords.escape(patch.new_file_full_path.to_s)
-        Open3.popen3("#{stylelint_executable} #{escaped_file_path} #{cli_options}") do |_stdin, stdout, stderr, thread|
+        Open3.popen3(cli_command(escaped_file_path)) do |_stdin, stdout, stderr, thread|
           status = thread.value
           json = stdout.read
-          if status.to_i == 0 && json.length == 0
+          if status.to_i.zero? && json.empty?
             []
           else
-            json = stderr.read if json.length == 0
+            json = stderr.read if json.empty?
             JSON.parse(json)
           end
         end
@@ -100,9 +88,9 @@ module Pronto
       # 2. Get the messages for that file
       # 3. Ignore errors without a line number for now
       output
-        .select { |offence| offence['warnings'].size > 0 }
-        .map { |offence| offence['warnings'] }
-        .flatten.select { |offence| offence['line'] }
+        .select { |offence| offence['warnings'].size.positive? }
+        .flat_map { |offence| offence['warnings'] }
+        .select { |offence| offence['line'] }
     end
   end
 end

--- a/lib/pronto/stylelint.rb
+++ b/lib/pronto/stylelint.rb
@@ -9,11 +9,7 @@ module Pronto
   class Stylelint < Runner
     extend Forwardable
 
-    CONFIG_FILE = '.pronto_stylelint.yml'
-    CONFIG_KEYS = %w[stylelint_executable files_to_lint cli_options].freeze
-    DEPRECATED_CONFIG =
-      "Pronto::Stylelint: Using %<config_key>s from #{CONFIG_FILE} is deprecated. " \
-      'Use .pronto.yml instead.'
+    attr_reader :stylelint_config
 
     def_delegators(
       :stylelint_config,
@@ -26,6 +22,8 @@ module Pronto
 
     def initialize(patches, commit = nil)
       super
+
+      @stylelint_config ||= Pronto::Stylelint::Config.new
     end
 
     def run
@@ -57,10 +55,6 @@ module Pronto
       level = :warning
 
       Message.new(path, line, level, offence['text'], nil, self.class)
-    end
-
-    def stylelint_config
-      @stylelint_config ||= Pronto::Stylelint::Config.new
     end
 
     def style_file?(path)

--- a/lib/pronto/stylelint/config.rb
+++ b/lib/pronto/stylelint/config.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'pronto'
+
+module Pronto
+  class Stylelint < Runner
+    class Config
+      CONFIG_FILE = '.pronto_stylelint.yml'
+      CONFIG_KEYS = %w[stylelint_executable files_to_lint cli_options].freeze
+      DEPRECATED_CONFIG =
+        "Pronto::Stylelint: Using %<config_key>s from #{CONFIG_FILE} is deprecated. " \
+        'Use .pronto.yml instead.'
+
+      attr_writer :stylelint_executable, :cli_options
+
+      def initialize
+        read_config
+      end
+
+      def stylelint_executable
+        stylelint_config['stylelint_executable'] || @stylelint_executable || 'stylelint'
+      end
+
+      def cli_options
+        "#{stylelint_config['cli_options'] || @cli_options} -f json".strip
+      end
+
+      def files_to_lint
+        config_files_to_lint || @files_to_lint || /\.(c|sc|sa|le)ss$/.freeze
+      end
+
+      def files_to_lint=(regexp)
+        @files_to_lint = regexp.is_a?(Regexp) ? regexp : Regexp.new(regexp)
+      end
+
+      def read_config
+        config_file = File.join(git_repo_path, CONFIG_FILE)
+        return unless File.exist?(config_file)
+
+        config = YAML.load_file(config_file)
+
+        CONFIG_KEYS.each do |config_key|
+          next unless config[config_key]
+
+          warn format(DEPRECATED_CONFIG, config_key: config_key)
+          send("#{config_key}=", config[config_key])
+        end
+      end
+
+      def git_repo_path
+        @git_repo_path ||= Rugged::Repository.discover(File.expand_path(Dir.pwd)).workdir
+      end
+
+      private
+
+      def config_files_to_lint
+        return unless stylelint_config['files_to_lint']
+
+        if stylelint_config['files_to_lint'].is_a?(Regexp)
+          stylelint_config['files_to_lint']
+        else
+          Regexp.new(stylelint_config['files_to_lint'])
+        end
+      end
+
+      def stylelint_config
+        @stylelint_config ||= Pronto::ConfigFile.new.to_h['stylelint'] || {}
+      end
+    end
+  end
+end

--- a/lib/pronto/stylelint/config.rb
+++ b/lib/pronto/stylelint/config.rb
@@ -5,46 +5,19 @@ require 'pronto'
 module Pronto
   class Stylelint < Runner
     class Config
-      CONFIG_FILE = '.pronto_stylelint.yml'
-      CONFIG_KEYS = %w[stylelint_executable files_to_lint cli_options].freeze
-      DEPRECATED_CONFIG =
-        "Pronto::Stylelint: Using %<config_key>s from #{CONFIG_FILE} is deprecated. " \
-        'Use .pronto.yml instead.'
-
-      attr_writer :stylelint_executable, :cli_options
-
-      def initialize
-        read_config
-      end
+      EXECUTABLE_DEFAULT = 'stylelint'
+      FILES_TO_LINT_DEFAULT = /\.(c|sc|sa|le)ss$/.freeze
 
       def stylelint_executable
-        stylelint_config['stylelint_executable'] || @stylelint_executable || 'stylelint'
+        stylelint_config['stylelint_executable'] || EXECUTABLE_DEFAULT
       end
 
       def cli_options
-        "#{stylelint_config['cli_options'] || @cli_options} -f json".strip
+        "#{stylelint_config['cli_options']} -f json".strip
       end
 
       def files_to_lint
-        config_files_to_lint || @files_to_lint || /\.(c|sc|sa|le)ss$/.freeze
-      end
-
-      def files_to_lint=(regexp)
-        @files_to_lint = regexp.is_a?(Regexp) ? regexp : Regexp.new(regexp)
-      end
-
-      def read_config
-        config_file = File.join(git_repo_path, CONFIG_FILE)
-        return unless File.exist?(config_file)
-
-        config = YAML.load_file(config_file)
-
-        CONFIG_KEYS.each do |config_key|
-          next unless config[config_key]
-
-          warn format(DEPRECATED_CONFIG, config_key: config_key)
-          send("#{config_key}=", config[config_key])
-        end
+        config_files_to_lint || FILES_TO_LINT_DEFAULT
       end
 
       def git_repo_path

--- a/lib/pronto/stylelint/linter.rb
+++ b/lib/pronto/stylelint/linter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'pronto'
+require 'shellwords'
+require 'open3'
+
+module Pronto
+  class Stylelint < Runner
+    class Linter
+      extend Forwardable
+
+      attr_reader :stylelint_config
+
+      def_delegators(
+        :stylelint_config,
+        :stylelint_executable,
+        :cli_options,
+        :git_repo_path
+      )
+
+      private :stylelint_executable, :cli_options, :git_repo_path
+
+      STYLELINT_FAILURE = 'Stylelint failed to run'
+      STATUS_CODES = {
+        0 => :success,
+        1 => :fatal_error,
+        2 => :lint_problem,
+        64 => :invalid_cli_usage,
+        78 => :invalid_configuration_file
+      }.freeze
+
+      def initialize(patch, stylelint_config)
+        @patch = patch
+        @stylelint_config = stylelint_config
+        @stylint_major_version = nil
+      end
+
+      def run
+        Dir.chdir(git_repo_path) do
+          Open3.popen3(cli_command) do |_stdin, stdout, stderr, thread|
+            JSON.parse(
+              case thread_status(thread)
+              when :success, :lint_problem
+                out = stdout.read
+                out.empty? ? stderr.read : out
+              else
+                puts "#{STYLELINT_FAILURE} - #{thread_status(thread)}:\n#{stderr.read}"
+                '[]'
+              end
+            )
+          end
+        end
+      end
+
+      private
+
+      def cli_command
+        "#{stylelint_executable} #{escaped_file_path} #{cli_options}"
+      end
+
+      def escaped_file_path
+        Shellwords.escape(@patch.new_file_full_path.to_s)
+      end
+
+      # Status codes:
+      # https://stylelint.io/user-guide/cli/#exit-codes
+      def thread_status(thread)
+        STATUS_CODES[thread.value.exitstatus] || :unknown
+      end
+    end
+  end
+end

--- a/lib/pronto/stylelint/version.rb
+++ b/lib/pronto/stylelint/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pronto
   module StylelintVersion
     VERSION = '0.10.3'.freeze

--- a/lib/pronto/stylelint/version.rb
+++ b/lib/pronto/stylelint/version.rb
@@ -2,6 +2,6 @@
 
 module Pronto
   module StylelintVersion
-    VERSION = '0.10.3'.freeze
+    VERSION = '0.11.0'
   end
 end

--- a/pronto-stylelint.gemspec
+++ b/pronto-stylelint.gemspec
@@ -1,5 +1,6 @@
-# -*- encoding: utf-8 -*-
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 require 'pronto/stylelint/version'
 
@@ -10,22 +11,18 @@ Gem::Specification.new do |s|
   s.authors = ['Kevin Jalbert']
   s.email = 'kevin.j.jalbert@gmail.com'
   s.homepage = 'https://github.com/kevinjalbert/pronto-stylelint'
-  s.summary = <<-EOF
+  s.summary = <<-SUMMARY
     Pronto runner for stylelint, the mighty, modern CSS linter.
-  EOF
+  SUMMARY
 
   s.licenses = ['MIT']
   s.required_ruby_version = '>= 2.3.0'
-  s.rubygems_version = '1.8.23'
 
-  s.files = Dir.glob('{lib}/**/*') + %w(LICENSE README.md)
-  s.test_files = `git ls-files -- {spec}/*`.split("\n")
+  s.files = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
   s.requirements << 'stylelint (in PATH)'
 
   s.add_dependency('pronto', '>= 0.10', '< 0.12')
   s.add_dependency('rugged', '>= 0.24', '< 2.0')
-  s.add_development_dependency('rake', '~> 13.0')
-  s.add_development_dependency('rspec', '~> 3.4')
 end

--- a/spec/pronto/stylelint/config_spec.rb
+++ b/spec/pronto/stylelint/config_spec.rb
@@ -17,15 +17,6 @@ module Pronto
 
         context 'with custom cli_options' do
           before do
-            add_to_index('.pronto_stylelint.yml', "cli_options: '--test option'")
-            create_commit
-          end
-
-          it { expect(cli_options).to eq('--test option -f json') }
-        end
-
-        context 'with custom cli_options via the .pronto.yml' do
-          before do
             add_to_index('.pronto.yml', "stylelint:\n  cli_options: '--test option'")
             create_commit
           end
@@ -46,20 +37,6 @@ module Pronto
           include_context 'repo'
 
           before do
-            add_to_index('.pronto_stylelint.yml', "files_to_lint: '\\.css$'")
-            create_commit
-          end
-
-          it { expect(files_to_lint).to match('my_css.css') }
-          it { expect(files_to_lint).not_to match('my_less.less') }
-          it { expect(files_to_lint).not_to match('my_scss.scss') }
-          it { expect(files_to_lint).not_to match('my_sass.sass') }
-        end
-
-        context 'with custom files_to_lint via the .pronto.yml' do
-          include_context 'repo'
-
-          before do
             add_to_index('.pronto.yml', "stylelint:\n  files_to_lint: '\\.css$'")
             create_commit
           end
@@ -77,17 +54,6 @@ module Pronto
         it { expect(stylelint_executable).to eql('stylelint') }
 
         context 'with custom stylelint_executable' do
-          include_context 'repo'
-
-          before do
-            add_to_index('.pronto_stylelint.yml', "stylelint_executable: 'custom_stylelint'")
-            create_commit
-          end
-
-          it { expect(stylelint_executable).to eql('custom_stylelint') }
-        end
-
-        context 'with custom stylelint_executable via the .pronto.yml' do
           include_context 'repo'
 
           before do

--- a/spec/pronto/stylelint/config_spec.rb
+++ b/spec/pronto/stylelint/config_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Pronto
+  class Stylelint
+    describe Config do
+      let(:config) { Config.new }
+      let(:patches) { [] }
+
+      describe '#cli_options' do
+        subject(:cli_options) { config.cli_options }
+
+        include_context 'repo'
+
+        it { expect(cli_options).to eq('-f json') }
+
+        context 'with custom cli_options' do
+          before do
+            add_to_index('.pronto_stylelint.yml', "cli_options: '--test option'")
+            create_commit
+          end
+
+          it { expect(cli_options).to eq('--test option -f json') }
+        end
+
+        context 'with custom cli_options via the .pronto.yml' do
+          before do
+            add_to_index('.pronto.yml', "stylelint:\n  cli_options: '--test option'")
+            create_commit
+          end
+
+          it { expect(cli_options).to eq('--test option -f json') }
+        end
+      end
+
+      describe '#files_to_lint' do
+        subject(:files_to_lint) { config.files_to_lint }
+
+        it { expect(files_to_lint).to match('my_css.css') }
+        it { expect(files_to_lint).to match('my_less.less') }
+        it { expect(files_to_lint).to match('my_scss.scss') }
+        it { expect(files_to_lint).to match('my_sass.sass') }
+
+        context 'with custom files_to_lint' do
+          include_context 'repo'
+
+          before do
+            add_to_index('.pronto_stylelint.yml', "files_to_lint: '\\.css$'")
+            create_commit
+          end
+
+          it { expect(files_to_lint).to match('my_css.css') }
+          it { expect(files_to_lint).not_to match('my_less.less') }
+          it { expect(files_to_lint).not_to match('my_scss.scss') }
+          it { expect(files_to_lint).not_to match('my_sass.sass') }
+        end
+
+        context 'with custom files_to_lint via the .pronto.yml' do
+          include_context 'repo'
+
+          before do
+            add_to_index('.pronto.yml', "stylelint:\n  files_to_lint: '\\.css$'")
+            create_commit
+          end
+
+          it { expect(files_to_lint).to match('my_css.css') }
+          it { expect(files_to_lint).not_to match('my_less.less') }
+          it { expect(files_to_lint).not_to match('my_scss.scss') }
+          it { expect(files_to_lint).not_to match('my_sass.sass') }
+        end
+      end
+
+      describe '#stylelint_executable' do
+        subject(:stylelint_executable) { config.stylelint_executable }
+
+        it { expect(stylelint_executable).to eql('stylelint') }
+
+        context 'with custom stylelint_executable' do
+          include_context 'repo'
+
+          before do
+            add_to_index('.pronto_stylelint.yml', "stylelint_executable: 'custom_stylelint'")
+            create_commit
+          end
+
+          it { expect(stylelint_executable).to eql('custom_stylelint') }
+        end
+
+        context 'with custom stylelint_executable via the .pronto.yml' do
+          include_context 'repo'
+
+          before do
+            add_to_index('.pronto.yml', "stylelint:\n  stylelint_executable: 'custom_stylelint'")
+            create_commit
+          end
+
+          it { expect(stylelint_executable).to eql('custom_stylelint') }
+        end
+      end
+    end
+  end
+end

--- a/spec/pronto/stylelint/linter_spec.rb
+++ b/spec/pronto/stylelint/linter_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Pronto
+  class Stylelint
+    describe Linter do
+      let(:linter) { described_class.new(patch, Config.new) }
+
+      describe '#run' do
+        subject(:run) { linter.run }
+
+        include_context 'repo'
+        let(:patch) { Pronto::Git::Repository.new(repository_dir).diff('main').first }
+
+        context 'with patch data' do
+          before do
+            stylelint_config = <<-HEREDOC
+              {
+                "rules": {
+                  "color-named": "never",
+                  "unit-no-unknown": true
+                }
+              }
+            HEREDOC
+
+            content = <<-HEREDOC
+              .thing {
+                font-size: 10pxem;
+              }
+            HEREDOC
+
+            add_to_index('.stylelintrc.json', stylelint_config)
+            add_to_index('style.css', content)
+
+            create_commit
+          end
+
+          context 'with warnings' do
+            before do
+              create_branch('staging', checkout: true)
+
+              add_to_index('style.css', <<-HEREDOC)
+                .thing {
+                  font-size:  10pxem;
+                }
+
+                a { color: pink;}
+              HEREDOC
+
+              add_to_index('style.scss', <<-HEREDOC)
+                .thing {
+                  font-size:  10pxem;
+
+                  a { color: pink;}
+                }
+              HEREDOC
+
+              create_commit
+            end
+
+            it { expect(run.count).to eql(1) }
+            it { expect(run.first).to be_a(Hash) }
+            it { expect(run.first['errored']).to eql(true) }
+            it { expect(run.first['warnings'].size).to eql(2) }
+            it { expect(run.first['warnings'].first['severity']).to eql('error') }
+            it {
+              expect(run.first['warnings'].first['text']).to eql(
+                'Unexpected named color "pink" (color-named)'
+              )
+            }
+            it { expect(run.first['warnings'].last['severity']).to eql('error') }
+            it {
+              expect(run.first['warnings'].last['text']).to eql(
+                'Unexpected unknown unit "pxem" (unit-no-unknown)'
+              )
+            }
+          end
+
+          context 'with custom stylelint_executable' do
+            before do
+              create_branch('staging', checkout: true)
+
+              updated_content = <<-HEREDOC
+                .thing {
+                  font-size:  10px;
+                }
+
+                a { color: pink;}
+              HEREDOC
+
+              add_to_index('style.css', updated_content)
+              add_to_index('.pronto.yml', "stylelint:\n  stylelint_executable: './custom_stylelint'")
+              add_to_index('custom_stylelint', "printf 'custom stylelint called'")
+
+              create_commit
+            end
+
+            it { expect { run }.to raise_error(JSON::ParserError, /custom stylelint called/) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pronto/stylelint_spec.rb
+++ b/spec/pronto/stylelint_spec.rb
@@ -76,7 +76,7 @@ module Pronto
 
           context 'with files to lint config that matches only .css' do
             before do
-              add_to_index('.pronto_stylelint.yml', "files_to_lint: '\\.css$'")
+              add_to_index('.pronto.yml', "stylelint:\n  files_to_lint: '\\.css$'")
               create_commit
             end
 
@@ -85,7 +85,7 @@ module Pronto
 
           context 'with files to lint config that never matches' do
             before do
-              add_to_index('.pronto_stylelint.yml', "files_to_lint: 'will never match'")
+              add_to_index('.pronto.yml', "stylelint:\n  files_to_lint: 'will never match'")
               create_commit
             end
 
@@ -118,7 +118,7 @@ module Pronto
             HEREDOC
 
             add_to_index('style.css', updated_content)
-            add_to_index('.pronto_stylelint.yml', "stylelint_executable: './custom_stylelint'")
+            add_to_index('.pronto.yml', "stylelint:\n  stylelint_executable: './custom_stylelint'")
             add_to_index('custom_stylelint', "printf 'custom stylelint called'")
 
             create_commit

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 
 require 'rspec'
 require 'pronto/stylelint'
 
-Dir.glob(Dir.pwd + '/spec/support/**/*.rb') { |file| require file }
+Dir.glob("#{Dir.pwd}/spec/support/**/*.rb").sort.each { |file| require file }
 
 RSpec.configure do |c|
   c.include RepositoryHelper

--- a/spec/support/repository_helper.rb
+++ b/spec/support/repository_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 
 module RepositoryHelper
@@ -15,16 +17,16 @@ module RepositoryHelper
   end
 
   def repository_dir
-    File.realpath(tmp_git_dir) + '/'
+    "#{File.realpath(tmp_git_dir)}/"
   end
 
   def current_branch_name
-    repo.head.name.sub(/^refs\/heads\//, '')
+    repo.head.name.sub(%r{^refs/heads/}, '')
   end
 
   def add_to_index(file_name, blob_content)
     object_id = repo.write(blob_content, :blob)
-    repo.index.add(path: file_name, oid: object_id, mode: 0100755)
+    repo.index.add(path: file_name, oid: object_id, mode: 0o100755)
     repo.index.write
   end
 

--- a/spec/support/shared_examples/repo.rb
+++ b/spec/support/shared_examples/repo.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'repo' do
+  around(:example) do |example|
+    create_repository
+    Dir.chdir(repository_dir) do
+      example.run
+    end
+    delete_repository
+  end
+end


### PR DESCRIPTION
# Motivation

Updating to Stylelint version 16 + returns an empty output for valid warnings

# Changes

- Move the linter to another class
- Handle thread exit codes in order to parse the output correctly
- Parse the stderr output for linter warnings
- Add specs

# Other

This will contain the changes for the new configuration as well. 
This can merge both or the config changes can be merged before this one.
See https://github.com/kevinjalbert/pronto-stylelint/pull/15
